### PR TITLE
zammad: 5.1.0 -> 5.1.1

### DIFF
--- a/pkgs/applications/networking/misc/zammad/default.nix
+++ b/pkgs/applications/networking/misc/zammad/default.nix
@@ -21,7 +21,7 @@
 
 let
   pname = "zammad";
-  version = "5.1.0";
+  version = "5.1.1";
 
   src = applyPatches {
 

--- a/pkgs/applications/networking/misc/zammad/gemset.nix
+++ b/pkgs/applications/networking/misc/zammad/gemset.nix
@@ -664,10 +664,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "04vxmjr200akcil9fqxc9ghbb9q0lyrh2q03xxncycd5vln910fi";
+      sha256 = "1pfk942d6qwhw151hxaz7n4knk6whyxqvvywdx2cdw9yhykyaqzq";
       type = "gem";
     };
-    version = "6.2.0";
+    version = "6.2.1";
   };
   factory_bot_rails = {
     dependencies = ["factory_bot" "railties"];
@@ -1452,10 +1452,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1p6b3q411h2mw4dsvhjrp1hh66hha5cm69fqg85vn2lizz71n6xz";
+      sha256 = "1g43ii497cwdqhfnaxfl500bq5yfc5hfv5df1lvf6wcjnd708ihd";
       type = "gem";
     };
-    version = "1.13.3";
+    version = "1.13.4";
   };
   nori = {
     groups = ["default"];
@@ -1700,10 +1700,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "19mf9f5zx23cjjn0p77wz1igzpfr22mxhljgavffl8fwqq74v4ih";
+      sha256 = "01ldw5ba6xfn2k97n75n52qs4f0fy8xmn58c4247xf476nfvg035";
       type = "gem";
     };
-    version = "3.2.5";
+    version = "3.2.6";
   };
   power_assert = {
     groups = ["default" "development" "test"];
@@ -1786,10 +1786,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "1xvkz9xrd1cqnlm0qac1iwwxzndx3cc17zrjncpa4lzjfwbxhsnm";
+      sha256 = "0df9bknc2dllk8v9fhgidzbvbryaxa8fgifrk40cdz9csjsphbky";
       type = "gem";
     };
-    version = "4.3.11";
+    version = "4.3.12";
   };
   pundit = {
     dependencies = ["activesupport"];
@@ -1832,6 +1832,17 @@
       type = "gem";
     };
     version = "2.2.3";
+  };
+  rack-attack = {
+    dependencies = ["rack"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rc6simyql7ax5zzp667x6krl0xxxh3asc1av6gcn8j6cyl86wsx";
+      type = "gem";
+    };
+    version = "6.6.0";
   };
   rack-livereload = {
     dependencies = ["rack"];
@@ -2273,10 +2284,10 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "134zg0dzd7216lyczkhv01v27ikkmipjihcy2bzi0qv72p1i923i";
+      sha256 = "1wybcipkfawg4pragmayiig03xc084x3hbwywsh1dr9x9pa8f9hj";
       type = "gem";
     };
-    version = "1.1.5";
+    version = "1.1.6";
   };
   slack-notifier = {
     groups = ["default"];

--- a/pkgs/applications/networking/misc/zammad/package.json
+++ b/pkgs/applications/networking/misc/zammad/package.json
@@ -14,5 +14,5 @@
     "stylelint-prettier": "^2.0.0"
   },
   "name": "Zammad",
-  "version": "5.1.0"
+  "version": "5.1.1"
 }

--- a/pkgs/applications/networking/misc/zammad/source.json
+++ b/pkgs/applications/networking/misc/zammad/source.json
@@ -1,7 +1,8 @@
 {
   "owner": "zammad",
   "repo": "zammad",
-  "rev": "eefae45c2ad6e6a96b8df631d2f50f290ecbd27d",
-  "sha256": "EjowvM//+UsAfEH9/0jgLkiD7EWH34M1NQ9U2DotBqc=",
+  "rev": "d71bd90ef964426230664cdfbaa2572325bfed4f",
+  "sha256": "yzDTkjnRBl71REtSKRblkanJWhj7gp/+exhWjxGCFWw=",
   "fetchSubmodules": true
 }
+


### PR DESCRIPTION
###### Description of changes

The update includes a fix for CVE-2022-29700 and CVE-2022-29701.

Fixes X

I tested the update on our test environment and everything looks good.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
